### PR TITLE
Add new default value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,12 @@ resource "aws_cognito_user_pool" "user_pool" {
     allow_admin_create_user_only = var.admin_create_user
   }
   password_policy {
-    minimum_length    = var.password_policy_minimum_length
-    require_lowercase = var.password_policy_require_lowercase
-    require_uppercase = var.password_policy_require_uppercase
-    require_numbers   = var.password_policy_require_numbers
-    require_symbols   = var.password_policy_require_symbols
+    minimum_length                   = var.password_policy_minimum_length
+    require_lowercase                = var.password_policy_require_lowercase
+    require_uppercase                = var.password_policy_require_uppercase
+    require_numbers                  = var.password_policy_require_numbers
+    require_symbols                  = var.password_policy_require_symbols
+    temporary_password_validity_days = var.password_policy_temporary_password_validity_days
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,11 @@ variable "password_policy_require_symbols" {
   default     = false
 }
 
+variable "password_policy_temporary_password_validity_days" {
+  description = "A container for information about the user pool password policy."
+  default     = 7
+}
+
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.12.26"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.47.0"
+    }
+  }
+}


### PR DESCRIPTION
- Add a new default value for the password validity to avoid perpetual diff
- Set a lower bound on Terraform and AWS provider version requirements